### PR TITLE
Fix - 1.20.1 biome colors being unintentionally set to non Addonslib dependent mods, like create, causing items to turn a green tint unintentionally

### DIFF
--- a/1.20.1/src/main/java/fr/samlegamer/addonslib/client/ColorRegistry.java
+++ b/1.20.1/src/main/java/fr/samlegamer/addonslib/client/ColorRegistry.java
@@ -1,50 +1,70 @@
 package fr.samlegamer.addonslib.client;
 
 import java.util.Map;
+
 import fr.addonslib.api.client.McwColors;
 import fr.samlegamer.addonslib.Finder;
 import net.minecraft.client.renderer.BiomeColors;
 import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.FoliageColor;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.LeavesBlock;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.event.RegisterColorHandlersEvent;
 
-@OnlyIn(value = Dist.CLIENT)
-public class ColorRegistry
-{
-	private final McwColors mcwColors;
+@OnlyIn(Dist.CLIENT)
+public class ColorRegistry {
 
-	public ColorRegistry(McwColors mcwColors)
-	{
-		this.mcwColors = mcwColors;
-	}
+    private final McwColors mcwColors;
 
-	public void registryBlockColors(RegisterColorHandlersEvent.Block event) {
-		for(Map.Entry<String, Integer> entry : mcwColors.getNoColorLeaves().entrySet()) {
-			String value = entry.getKey();
-			Block block = Finder.findBlock(value);
-			event.register((state, view, pos, tintIndex) -> entry.getValue(), block);
-		}
-	}
+    public ColorRegistry(McwColors mcwColors) {
+        this.mcwColors = mcwColors;
+    }
 
-	public void registryItemColors(RegisterColorHandlersEvent.Item event) {
-		for(Map.Entry<String, Integer> entry : mcwColors.getNoColorLeaves().entrySet()) {
-			String value = entry.getKey();
-			Block hedges = Finder.findBlock(value);
-			event.register((stack, tintIndex) -> {
-				Block block = ((BlockItem) stack.getItem()).getBlock();
-				return event.getBlockColors().getColor(block.defaultBlockState(), null, null, tintIndex);
-			}, hedges);
-		}
-	}
+    public void registryBlockColors(RegisterColorHandlersEvent.Block event) {
+        for (Map.Entry<String, Integer> entry : mcwColors.getNoColorLeaves().entrySet()) {
+            Block block = Finder.findBlock(entry.getKey());
 
-	public void registryBlockColorsAverage(RegisterColorHandlersEvent.Block event) {
-		for(Map.Entry<String, Integer> entry : mcwColors.getNoColorLeaves().entrySet()) {
-			String value = entry.getKey();
-			Block block = Finder.findBlock(value);
-			event.register((state, view, pos, tintIndex) -> view != null && pos != null ? BiomeColors.getAverageFoliageColor(view, pos) : FoliageColor.get(0.5D, 1.0D), block);
-		}
-	}
+            if (block instanceof LeavesBlock) {
+                int color = entry.getValue();
+                event.register((state, view, pos, tintIndex) -> color, block);
+            }
+        }
+    }
+
+    public void registryItemColors(RegisterColorHandlersEvent.Item event) {
+        for (Map.Entry<String, Integer> entry : mcwColors.getNoColorLeaves().entrySet()) {
+            Block block = Finder.findBlock(entry.getKey());
+
+            if (block instanceof LeavesBlock) {
+                event.register((stack, tintIndex) -> {
+                    if (!(stack.getItem() instanceof BlockItem blockItem)) {
+                        return -1;
+                    }
+
+                    Block b = blockItem.getBlock();
+                    return event.getBlockColors().getColor(
+                        b.defaultBlockState(), null, null, tintIndex
+                    );
+                }, block);
+            }
+        }
+    }
+
+    public void registryBlockColorsAverage(RegisterColorHandlersEvent.Block event) {
+        for (Map.Entry<String, Integer> entry : mcwColors.getNoColorLeaves().entrySet()) {
+            Block block = Finder.findBlock(entry.getKey());
+
+            if (block instanceof LeavesBlock) {
+                event.register((state, view, pos, tintIndex) ->
+                    (view != null && pos != null)
+                        ? BiomeColors.getAverageFoliageColor(view, pos)
+                        : FoliageColor.get(0.5D, 1.0D),
+                    block
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
### Issue


The foliage color handler in ColorRegistry is currently applied to all blocks returned by Finder.findBlock, without verifying that the block is actually foliage.

This can result in unintended biome tinting being applied to non-foliage blocks (e.g. blocks from other mods appearing green).

Seeks to fix: https://github.com/Samlegamer/Macaw-s-Addons/issues/83


### Changes

- Added a type check (instanceof LeavesBlock) before registering color handlers
- Ensures only leaf blocks receive biome foliage tinting

### Result

- Prevents incorrect tinting on non-leaf blocks
- Aligns behavior with vanilla foliage coloring logic

<img width="850" height="483" alt="Screenshot 2026-04-17 002506" src="https://github.com/user-attachments/assets/4dd1c9fd-0954-4040-af63-59a91748334d" />
